### PR TITLE
Add MinIO storage for product images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,20 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
+  minio:
+    image: minio/minio
+    container_name: ecommerce-minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
 volumes:
   catalog_pgdata:
   auth_pgdata:
+  minio_data:

--- a/services/catalog-svc/build.gradle
+++ b/services/catalog-svc/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    implementation 'io.minio:minio:8.5.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'

--- a/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/config/MinioConfig.java
+++ b/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/config/MinioConfig.java
@@ -1,0 +1,30 @@
+package org.olzhas.catalogsvc.config;
+
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(MinioProperties.class)
+public class MinioConfig {
+
+    @Bean
+    public MinioClient minioClient(MinioProperties props) {
+        return MinioClient.builder()
+                .endpoint(props.getUrl())
+                .credentials(props.getAccessKey(), props.getSecretKey())
+                .build();
+    }
+
+    @Bean
+    public Object bucketInitializer(MinioClient client, MinioProperties props) throws Exception {
+        boolean exists = client.bucketExists(BucketExistsArgs.builder().bucket(props.getBucket()).build());
+        if (!exists) {
+            client.makeBucket(MakeBucketArgs.builder().bucket(props.getBucket()).build());
+        }
+        return new Object();
+    }
+}

--- a/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/config/MinioProperties.java
+++ b/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/config/MinioProperties.java
@@ -1,0 +1,43 @@
+package org.olzhas.catalogsvc.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "minio")
+public class MinioProperties {
+    private String url;
+    private String accessKey;
+    private String secretKey;
+    private String bucket;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+}

--- a/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/controller/publicapi/ProductController.java
+++ b/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/controller/publicapi/ProductController.java
@@ -7,6 +7,13 @@ import org.olzhas.catalogsvc.dto.ProductDto;
 import org.olzhas.catalogsvc.dto.ProductFilter;
 import org.olzhas.catalogsvc.dto.ProductImageDto;
 import org.olzhas.catalogsvc.service.ProductService;
+import org.olzhas.catalogsvc.service.image.ProductImageService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -24,6 +31,7 @@ import java.util.UUID;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductImageService productImageService;
 
     @GetMapping
     public PageResponse<ProductDto> list(@PageableDefault(size = 25, sort = "id,desc") Pageable pageable) {
@@ -44,5 +52,20 @@ public class ProductController {
     @GetMapping("/{id}/images")
     public List<ProductImageDto> images(@PathVariable UUID id) {
         return productService.getImages(id);
+    }
+
+    @PostMapping("/{id}/images")
+    public ProductImageDto upload(@PathVariable UUID id,
+                                 @RequestParam("file") MultipartFile file,
+                                 @RequestParam(value = "primary", defaultValue = "false") boolean primary) {
+        return productImageService.upload(id, file, primary);
+    }
+
+    @GetMapping("/images/{imageId}")
+    public ResponseEntity<Resource> download(@PathVariable UUID imageId) {
+        Resource resource = productImageService.download(imageId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + imageId)
+                .body(resource);
     }
 }

--- a/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/service/image/ProductImageService.java
+++ b/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/service/image/ProductImageService.java
@@ -1,0 +1,12 @@
+package org.olzhas.catalogsvc.service.image;
+
+import org.olzhas.catalogsvc.dto.ProductImageDto;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public interface ProductImageService {
+    ProductImageDto upload(UUID productId, MultipartFile file, boolean primary);
+    Resource download(UUID imageId);
+}

--- a/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/service/image/ProductImageServiceImpl.java
+++ b/services/catalog-svc/src/main/java/org/olzhas/catalogsvc/service/image/ProductImageServiceImpl.java
@@ -1,0 +1,76 @@
+package org.olzhas.catalogsvc.service.image;
+
+import io.minio.GetObjectArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import org.olzhas.catalogsvc.config.MinioProperties;
+import org.olzhas.catalogsvc.dto.ProductImageDto;
+import org.olzhas.catalogsvc.exceptionHandler.NotFoundException;
+import org.olzhas.catalogsvc.mapper.ProductImageMapper;
+import org.olzhas.catalogsvc.model.Product;
+import org.olzhas.catalogsvc.model.ProductImage;
+import org.olzhas.catalogsvc.repository.ProductImageRepository;
+import org.olzhas.catalogsvc.repository.ProductRepository;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductImageServiceImpl implements ProductImageService {
+
+    private final ProductRepository productRepository;
+    private final ProductImageRepository productImageRepository;
+    private final ProductImageMapper productImageMapper;
+    private final MinioClient minioClient;
+    private final MinioProperties properties;
+
+    @Override
+    @Transactional
+    public ProductImageDto upload(UUID productId, MultipartFile file, boolean primary) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new NotFoundException("Product not found with id: " + productId));
+        String objectName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        try (InputStream is = file.getInputStream()) {
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(properties.getBucket())
+                            .object(objectName)
+                            .stream(is, file.getSize(), -1)
+                            .contentType(file.getContentType())
+                            .build());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload image", e);
+        }
+        ProductImage image = new ProductImage();
+        image.setProduct(product);
+        image.setS3Key(objectName);
+        image.setUrl(properties.getUrl() + "/" + properties.getBucket() + "/" + objectName);
+        image.setIsPrimary(primary);
+        ProductImage saved = productImageRepository.save(image);
+        return productImageMapper.toDto(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Resource download(UUID imageId) {
+        ProductImage image = productImageRepository.findById(imageId)
+                .orElseThrow(() -> new NotFoundException("Image not found with id: " + imageId));
+        try {
+            InputStream stream = minioClient.getObject(
+                    GetObjectArgs.builder()
+                            .bucket(properties.getBucket())
+                            .object(image.getS3Key())
+                            .build());
+            return new InputStreamResource(stream);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to download image", e);
+        }
+    }
+}

--- a/services/catalog-svc/src/main/resources/application.properties
+++ b/services/catalog-svc/src/main/resources/application.properties
@@ -11,3 +11,9 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+# MinIO configuration
+minio.url=http://localhost:9000
+minio.access-key=minioadmin
+minio.secret-key=minioadmin
+minio.bucket=product-images


### PR DESCRIPTION
## Summary
- add a MinIO container to docker-compose
- store MinIO connection settings in catalog service
- configure MinIO client bean
- implement `ProductImageService` for uploading/downloading images
- expose image upload and download endpoints
- include MinIO Java client dependency

## Testing
- `./gradlew test --no-daemon` *(fails: Flyway cannot connect to Postgres)*
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68428aa4b6908332b6ec3e62133c4203